### PR TITLE
Fix Trail and EDS delta function

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-11-14T23:13:14Z"
+  build_date: "2022-11-21T01:14:40Z"
   build_hash: 18745aa8d1126566776a4748c403ae891b889e9c
   go_version: go1.18.3
   version: v0.20.1-7-g18745aa
@@ -7,7 +7,7 @@ api_directory_checksum: 148b03b9487530212ba5b3222368450a6e3014b7
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 129c761755e7459f4797cf69401f9835f72f8888
+  file_checksum: f2ef8d53682ee442cd5bad668559800a12c91185
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -3,12 +3,17 @@ resources:
     fields:
       Name:
         is_immutable: true
+      Tags:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateTrail:
           input_fields:
             TagsList: Tags
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/trail/sdk_read_one_post_set_output.go.tpl
     update_operation:
@@ -33,6 +38,9 @@ resources:
         late_initaliaze: {}
       RetentionPeriod:
         late_initaliaze: {}
+      Tags:
+        compare:
+          is_ignored: true
     is_arn_primary_key: true
     renames:
       operations:

--- a/generator.yaml
+++ b/generator.yaml
@@ -3,12 +3,17 @@ resources:
     fields:
       Name:
         is_immutable: true
+      Tags:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateTrail:
           input_fields:
             TagsList: Tags
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/trail/sdk_read_one_post_set_output.go.tpl
     update_operation:
@@ -33,6 +38,9 @@ resources:
         late_initaliaze: {}
       RetentionPeriod:
         late_initaliaze: {}
+      Tags:
+        compare:
+          is_ignored: true
     is_arn_primary_key: true
     renames:
       operations:

--- a/pkg/resource/event_data_store/delta.go
+++ b/pkg/resource/event_data_store/delta.go
@@ -73,9 +73,6 @@ func newResourceDelta(
 			delta.Add("Spec.RetentionPeriod", a.ko.Spec.RetentionPeriod, b.ko.Spec.RetentionPeriod)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TerminationProtectionEnabled, b.ko.Spec.TerminationProtectionEnabled) {
 		delta.Add("Spec.TerminationProtectionEnabled", a.ko.Spec.TerminationProtectionEnabled, b.ko.Spec.TerminationProtectionEnabled)
 	} else if a.ko.Spec.TerminationProtectionEnabled != nil && b.ko.Spec.TerminationProtectionEnabled != nil {

--- a/pkg/resource/trail/delta.go
+++ b/pkg/resource/trail/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.CloudWatchLogsLogGroupARN, b.ko.Spec.CloudWatchLogsLogGroupARN) {
 		delta.Add("Spec.CloudWatchLogsLogGroupARN", a.ko.Spec.CloudWatchLogsLogGroupARN, b.ko.Spec.CloudWatchLogsLogGroupARN)
@@ -117,9 +118,6 @@ func newResourceDelta(
 		if *a.ko.Spec.SNSTopicName != *b.ko.Spec.SNSTopicName {
 			delta.Add("Spec.SNSTopicName", a.ko.Spec.SNSTopicName, b.ko.Spec.SNSTopicName)
 		}
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta


### PR DESCRIPTION
While running soak tests for cloudtrail-controller i came across an issue
where the controller doesn't properly compare tags field changes. More
specifically the delta function was expecting the tags array in the
desired and latest objects to have to same order.

This was not caught previously in the e2e tests because it's not
technically incorrect. Constatly returning that there is a diff for a
certain field causes the controller to attempt mutating the resource
state towards the desired state. Which is a correct reaction.

This patch fixes this issue by:
- Ignore the part that uses `reflect.DeepEqual` for both EDS and Trail
- Add missing `preCompare` hook for Trail resource.

No e2e tests needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
